### PR TITLE
Update name in Wrangler configuration file to match deployed Worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cloudflared-web",
+  "name": "skyroute-enterprise",
   "version": "1.0.0",
   "description": "Cloudflare Worker to proxy requests to Raspberry Pi services via Cloudflare Tunnel.",
   "main": "index.js",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,4 @@
-name = "workerdanver1"
+name = 'skyroute-enterprise'
 account_id = "4b373ad750503e164fba7edf76322413"
 main = "index.js"
 compatibility_date = "2025-04-08"


### PR DESCRIPTION
The Worker name in your Wrangler configuration file does not match the name of the deployed Worker in the Cloudflare Dashboard.
		Cloudflare automatically generated this PR to resolve the mismatch and avoid inconsistencies between environments. For more information, see: https://developers.cloudflare.com/workers/ci-cd/builds/troubleshoot/#workers-name-requirement